### PR TITLE
增加bin和#!/usr/bin/env node，可以在全局环境下安装并以receiver命令运行

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "FIS static receiver",
   "main": "server.js",
+  "bin": "server.js",
   "dependencies": {
     "formidable": "1.0.15",
     "mkdirp": "0.5.0"

--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var http = require('http');
 var formidable = require('formidable');
 var fs = require('fs');


### PR DESCRIPTION
增加bin和#!/usr/bin/env node，可以在全局环境下安装并以receiver命令运行

安装方式为：
$ git clone https://github.com/fex-team/receiver.git
$ cd receiver
$ npm install -g ./
运行方式：
$ receiver # default port 8999, use `node server.js <port>` change port
